### PR TITLE
Itemized indexing backup routine

### DIFF
--- a/modules/sqlfunctions.js
+++ b/modules/sqlfunctions.js
@@ -88,7 +88,9 @@ exports.insertFinalSql= function(sqlQuery) {
             
         }).catch(function (err) {
             //console.log(err);
+            console.log("//////////// The block could not be batch-indexed. Initiating its itemized indexing")
             dbConn.close();
+            itemizedIndexing(sqlBatch)
         });
     }).catch(function (err) {
         console.log(err);
@@ -267,3 +269,9 @@ function lastTxsStatsStep4 (landingArray) {
     }).catch(function (err) {});
 }
 
+
+function itemizedIndexing(sqlBatch) {
+    // This function indexes sequentially each query instead of the whole batch, as a backup plan if the batch fails
+
+
+}

--- a/navigator.js
+++ b/navigator.js
@@ -456,7 +456,7 @@ function blockRequest(remainingBlocks, poolsDb) {
                 for (var i = 0; i < sqlBatch.length; i++) {
                     var sqlQuery = sqlQuery + sqlBatch[i] + " "
                 }
-                SqlFunctions.insertFinalSql(sqlQuery)
+                SqlFunctions.insertFinalSql(sqlQuery, sqlBatch)
 
                 // Report
                 console.log("Block added: " + height + " - Txs: " + apiblock.transactions.length + " - SQL queries: " + sqlBatch.length)


### PR DESCRIPTION
This set of changes fixes an issue making approximately 1 out of 200 blocks to be truncated during the indexing. After this change, the number of missing transactions should be reduced considerably (maybe even no single missed TX)