### PR TITLE
Total fees count

### DIFF
--- a/modules/sqlfunctions.js
+++ b/modules/sqlfunctions.js
@@ -34,7 +34,7 @@ exports.insertSql= function(table, toAdd, toCheck) {
         var sqlQuery = "IF NOT EXISTS (SELECT Height FROM BlockInfo WHERE Height = " + toCheck
             + ") INSERT INTO BlockInfo (Height,Timestamp,TransactionCount,Hash,MinerPayoutAddress,MinerArbitraryData,Difficulty,Hashrate,"
             + "TotalCoins,SiacoinInputCount,SiacoinOutputCount,FileContractRevisionCount,StorageProofCount,SiafundInputCount,SiafundOutputCount,"
-            + "ActiveContractCost,ActiveContractCount,ActiveContractSize,TotalContractCost,TotalContractCount,TotalContractSize,NewContracts,NewTx,MiningPool"
+            + "ActiveContractCost,ActiveContractCount,ActiveContractSize,TotalContractCost,TotalContractCount,TotalContractSize,NewContracts,NewTx,MiningPool,FeeCount"
             + ") VALUES " + toAdd
     } else if (table == "HashTypes") {
         var sqlQuery = "IF NOT EXISTS (SELECT Hash FROM HashTypes WHERE Hash = '" + toCheck

--- a/navigator.js
+++ b/navigator.js
@@ -439,7 +439,7 @@ function blockRequest(remainingBlocks, poolsDb) {
                     + parseInt(apiblock.siafundinputcount) + "," + parseInt(apiblock.siafundoutputcount) + "," + parseInt(apiblock.activecontractcost) + ","
                     + parseInt(apiblock.activecontractcount) + "," + parseInt(apiblock.activecontractsize) + "," + parseInt(apiblock.totalcontractcost) + ","
                     + parseInt(apiblock.filecontractcount) + "," + parseInt(apiblock.totalcontractsize) + "," + newContracts + "," + newTransactions
-                    + ",'" + miningPool + "')"
+                    + ",'" + miningPool + "'," + parseInt(apiblock.minerfeecount) + ")"
                 sqlBatch.push(SqlFunctions.insertSql("BlockInfo", toAddBlockInfo, height));
 
                 // Block as a hash type

--- a/tools/create_tables.sql
+++ b/tools/create_tables.sql
@@ -58,6 +58,7 @@ CREATE TABLE [dbo].[BlockInfo](
 	[NewContracts] [smallint] NULL,
 	[NewTx] [smallint] NULL,
 	[MiningPool] [varchar](15) NULL,
+	[FeeCount] [numeric](36, 0) NULL,
  CONSTRAINT [PK_BlockInfo] PRIMARY KEY CLUSTERED 
 (
 	[Height] ASC

--- a/tools/navigator_gap_repair.js
+++ b/tools/navigator_gap_repair.js
@@ -333,7 +333,7 @@ function blockRequest(remainingBlocks, sqlBatch, poolsDb) {
                 + parseInt(apiblock.siafundinputcount) + "," + parseInt(apiblock.siafundoutputcount) + "," + parseInt(apiblock.activecontractcost) + ","
                 + parseInt(apiblock.activecontractcount) + "," + parseInt(apiblock.activecontractsize) + "," + parseInt(apiblock.totalcontractcost) + ","
                 + parseInt(apiblock.filecontractcount) + "," + parseInt(apiblock.totalcontractsize) + "," + newContracts + "," + newTransactions
-                + ",'" + miningPool + "')"
+                + ",'" + miningPool + "'," + parseInt(apiblock.minerfeecount) + ")"
             sqlBatch.push(SqlFunctions.insertSql("BlockInfo", toAddBlockInfo, height));
 
             // Block as a hash type


### PR DESCRIPTION
This PR adds the total miner's fees count to the `BlockInfo` table. It allows full compatibility with the rest of scripts of SiaStats