### PR TITLE
Foundation fork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 node_modules
+navigator.db
+navigator.db-journal
+web/nav_assets/navigator_styles.css
+.gitignore
+web/nav_assets/navigator_web.js
+status.json
+landingpagedata.json

--- a/modules/apifunctions.js
+++ b/modules/apifunctions.js
@@ -67,7 +67,12 @@ exports.Hash = async function(params, res, req) {
         txs.sort(function(a,b) {
             return parseFloat(b.Height) - parseFloat(a.Height)
         })
-        var firstSeen = txs[txs.length-1].Height
+        try {
+            var firstSeen = txs[txs.length-1].Height
+        } catch (e) {
+            var firstSeen = ""
+        }
+        
         var trimTxs = []
         for (var m = 0; m < 100 && m < txCount; m++) {
             trimTxs.push(txs[m])

--- a/modules/foundation.js
+++ b/modules/foundation.js
@@ -2,6 +2,10 @@
 var exports = module.exports={}
 var blake = require('blakejs')
 
+var SqlAsync = require('./modules/sql_async.js')
+var SqlComposer = require("./modules/sql_composer.js")
+var Commons = require('./commons.js')
+
 
 exports.CalculateOutputIdSubsidy = async function(blockHash, specifier) {
 	// This function takes the hash of a block together with the specifier of the Sia Foundation and calculates
@@ -38,4 +42,56 @@ exports.CalculateOutputIdSubsidy = async function(blockHash, specifier) {
 	var  outputIDString = Buffer.from(subsidyOutputID).toString('hex');
 
 	return outputIDString
+}
+
+
+exports.CheckCurrentFoundationAddresses = async function(params) {
+	// Checks with the Sia API if the Foundation or failover addresses have changed. If yes, it will update
+	// the table and reasign the unspent outputs to the new address
+
+	// Getting the latest set of addresses
+	var sqlQuery = SqlComposer.SelectTop(params, "FoundationAddressesChanges", "*", "Height", 1)
+	var sql = await SqlAsync.Sql(params, sqlQuery)
+
+	// Current addresses from the Sia API
+	var api = await Commons.MegaRouter(params, 0, '/consensus')
+    var currentFoundationAddress = api.foundationprimaryunlockhash
+	var currentFailoverAddress = api.foundationfailsafeunlockhash
+	var height = api.height
+
+	// Detecting a change on any of the two addresses. We will add a new entry if there was a change
+	if (sql[0].FoundationAddress != currentFoundationAddress || sql[0].FailoverAddress != currentFailoverAddress) {
+
+		// Inserting new entry on the Foundation addresses table
+		var sqlQuery = "INSERT INTO FoundationAddressesChanges (Height,FoundationAddress,FailoverAddress) VALUES "
+        	+ "(" + height + ",'" + foundationAddress + "','" + failoverAddress + "')"
+		await SqlAsync.Sql(params, sqlQuery)
+
+		if (sql[0].FoundationAddress != currentFoundationAddress) {
+			// Main Foundation address changed
+			console.log("**** Foundation address changed on block " + height + " to: " + currentFoundationAddress)
+			
+			// The ownership of all the unspent outputs of the Foundation need to be transferred to the new address
+			// A - Getting the list of outputs
+			var sqlQuery = "SELECT * FROM Outputs WHERE Spent = 0 AND FoundationUnclaimed = 1 AND Address = '" + sql[0].FoundationAddress + "'"
+			var outputsList = await SqlAsync.Sql(params, sqlQuery)
+			console.log("**** Updating the ownership of" + outputsList.length + " outputs")
+
+			// B - Updating Outputs
+			var sqlQuery = "UPDATE Outputs SET Address = '" + currentFoundationAddress + "' WHERE Spent = 0 AND FoundationUnclaimed = 1"
+				+ "AND Address = '" + sql[0].FoundationAddress + "'"
+			await SqlAsync.Sql(params, sqlQuery)
+
+			// C - Updating AddressesChanges
+			for (var i = 0; i < outputsList.length; i++) {
+				var sqlQuery = "UPDATE AddressChanges SET Address = '" + currentFoundationAddress + "' WHERE Address = '" + sql[0].FoundationAddress 
+					+ "' AND Height = " + outputsList[i].CreatedOnBlock
+				await SqlAsync.Sql(params, sqlQuery)
+			}
+
+		} else {
+			// Just the failover address changed. No need to update outputs
+			console.log("**** Foundation failover address changed on block " + height + " to: " + currentFailoverAddress)
+		}
+	}
 }

--- a/modules/foundation.js
+++ b/modules/foundation.js
@@ -1,0 +1,43 @@
+// Processes operations related to the Sia Foundation subsidies and wallets
+var exports = module.exports={}
+var blake = require('blakejs')
+
+
+
+
+function calculateOutputIdSubsidy(blockHash, specifier) {
+	// This function takes the hash of a block together with the specifier of the Sia Foundation and calculates
+	// with it the OutputID of a Foundation subsidy. It reproduces what the Sia code does in Golang
+	// This function is a courtesy of Nate Maninger, from https://SiaCentral.com, whom I am extremely grateful with for his help
+	
+	var specifierFoundation = newSpecifier(specifier);
+
+	function newSpecifier(str) {
+		// Takes the specifier and transforms it into a buffer
+		const buf = Buffer.alloc(16);
+		buf.write(str, encoding='ascii');
+		return buf;
+	}
+
+	function hashAll(...args) {
+		// Calculates the subsidy ID by hashing together the block ID bytes and foundation specifier
+
+		const hasher = blake.blake2bInit(32, null);
+
+		// loop through each of our arguments and update the hasher
+		for (let i = 0; i < args.length; i++)
+		blake.blake2bUpdate(hasher, args[i]);
+
+		//finalize the hash
+		return blake.blake2bFinal(hasher);
+	}
+
+	// convert the block ID from its hex encoded string to a Buffer
+	var blockID = Buffer.from(blockHash, 'hex');
+	// calculate the subsidy id
+	var subsidyOutputID = hashAll(blockID, specifierFoundation);
+	// convert the Buffer to a hex encoded ID string
+	var  outputIDString = Buffer.from(subsidyOutputID).toString('hex');
+
+	return outputIDString
+}

--- a/modules/foundation.js
+++ b/modules/foundation.js
@@ -3,9 +3,7 @@ var exports = module.exports={}
 var blake = require('blakejs')
 
 
-
-
-function calculateOutputIdSubsidy(blockHash, specifier) {
+exports.CalculateOutputIdSubsidy = async function(blockHash, specifier) {
 	// This function takes the hash of a block together with the specifier of the Sia Foundation and calculates
 	// with it the OutputID of a Foundation subsidy. It reproduces what the Sia code does in Golang
 	// This function is a courtesy of Nate Maninger, from https://SiaCentral.com, whom I am extremely grateful with for his help

--- a/modules/indexer.js
+++ b/modules/indexer.js
@@ -229,7 +229,7 @@ async function minerPayoutProcessor(params, sqlBatch, addressesImplicated, heigh
         blockRewardCoins = blockRewardCoins + subsidyAmount
 
         // Getting the current Foundation main address from database
-        var sqlQuery = "SELECT Height, FoundationAddress FROM FoundationAddressesChanges WHERE Height < " + height + " ORDER BY Height ASC"
+        var sqlQuery = "SELECT Height, FoundationAddress FROM FoundationAddressesChanges WHERE Height <= " + height + " ORDER BY Height ASC"
         var addressesList = await SqlAsync.Sql(params, sqlQuery)
         var currentFoundationAddress = addressesList[addressesList.length-1].FoundationAddress
 

--- a/modules/indexer.js
+++ b/modules/indexer.js
@@ -14,6 +14,7 @@ var ParentFinder = require("./parentfinder.js")
 var Metadata = require("./metadata.js")
 var SqlAsync = require('./sql_async.js')
 var SqlComposer = require("./sql_composer.js")
+var Foundation = require("./foundation.js")
 
 exports.BlockIndexer = async function(params, block) {
     // B - /consensus/blocks call to the megarouter
@@ -197,6 +198,7 @@ async function minerPayoutProcessor(params, sqlBatch, addressesImplicated, heigh
     // database. Instead, I create an artificial TxID where I replace the first two characters of the block hash by
     // a "BR" (block reward)
     var minerPayoutTxId = "BR" + api.id.slice(2)
+    var blockRewardCoins = BigInt(api.minerpayouts[0].value)
     
     // Address change. Add it to the Addresses Implicated array
     addressesImplicated.push({
@@ -207,12 +209,58 @@ async function minerPayoutProcessor(params, sqlBatch, addressesImplicated, heigh
         txType: 'blockreward'
     })
 
+    // Sia Foundation subsidies
+    var subsidyBool = false
+    // Initial Foundation subsidy
+    if (height == params.blockchain.foundationForkHeight) {
+        var subsidyAmount = params.blockchain.foundationInitialSubsidy
+        subsidyBool = true
+    }
+    // Monthly Foundation subsidy
+    if (height > params.blockchain.foundationForkHeight) {
+        if ((height - params.blockchain.foundationForkHeight) % params.blockchain.foundationSubsidyPeriodicity == 0) {
+            var subsidyAmount = params.blockchain.foundationSubsidy
+            subsidyBool = true
+        }
+    }
+
+    // Processing SQL entries for the Foundation
+    if (subsidyBool == true) {
+        blockRewardCoins = blockRewardCoins + subsidyAmount
+
+        // Getting the current Foundation main address from database
+        var sqlQuery = "SELECT Height, FoundationAddress FROM FoundationAddressesChanges WHERE Height < " + height + " ORDER BY Height ASC"
+        var addressesList = await SqlAsync.Sql(params, sqlQuery)
+        var currentFoundationAddress = addressesList[addressesList.length-1].FoundationAddress
+
+        // Calculating the output ID
+        var foundationOutputId = await Foundation.CalculateOutputIdSubsidy(api.id, params.blockchain.foundationSpecifier)
+
+        // Address Change. The txType is "foundationSub"
+        addressesImplicated.push({
+            hash: currentFoundationAddress, 
+            masterHash: minerPayoutTxId,
+            sc: subsidyAmount,
+            sf: 0,
+            txType: 'foundationsub'
+        })
+        
+        // Output as a hash type
+        var toAddHashTypes = "('" + foundationOutputId + "','output','')"
+        sqlBatch.push(SqlComposer.InsertSql(params, "HashTypes", toAddHashTypes, foundationOutputId))
+
+        // Adding the output info to the Batch
+        var sqlQuery = SqlComposer.CreateOutput(
+            params, "Outputs-SC-FoundationUnlciamed", foundationOutputId, subsidyAmount, currentFoundationAddress, height)
+        sqlBatch.push(sqlQuery)
+    }
+
     // Tx info
     var toAddTxInfo = "('" + minerPayoutTxId + "',''," + height + "," + timestamp + ",null)"
     sqlBatch.push(SqlComposer.InsertSql(params, "TxInfo", toAddTxInfo, minerPayoutTxId))
 
     // Saving TX as a component of a block
-    var toAddBlockTransactions = "(" + height + ",'" + minerPayoutTxId + "','blockreward'," + parseInt(api.minerpayouts[0].value) + ",0)"
+    var toAddBlockTransactions = "(" + height + ",'" + minerPayoutTxId + "','blockreward'," + blockRewardCoins + ",0)"
     sqlBatch.push(SqlComposer.InsertSql(params, "BlockTransactions", toAddBlockTransactions, minerPayoutTxId))
 
     // Miner payout as hash type

--- a/modules/metadata.js
+++ b/modules/metadata.js
@@ -35,7 +35,7 @@ exports.MetadataBlock = async function(params, api) {
         Difficulty: parseInt(api.difficulty),
         Hashrate: 0,
         TransactionCount: parseInt(prevBlock.TransactionCount),
-        TotalCoins: BigInt(prevBlock.TotalCoins) + blockReward(params, api.height),
+        TotalCoins: BigInt(prevBlock.TotalCoins) + blockReward(params, api.height) + foundationSubsidies(params, api.height),
         SiacoinInputCount: parseInt(prevBlock.SiacoinInputCount),
         SiacoinOutputCount: parseInt(prevBlock.SiacoinOutputCount),
         FileContractRevisionCount: parseInt(prevBlock.FileContractRevisionCount),
@@ -96,14 +96,33 @@ exports.MetadataBlock = async function(params, api) {
 }
 
 function blockReward(params, height) {
-    // Calculates the block reward
+    // Calculates the block reward - Mined coins
     var decay = (BigInt(height) * params.blockchain.decayBlockReward)
     var reward = params.blockchain.initialBlockReward - decay
     if (reward < params.blockchain.endBlockReward) {
         reward = params.blockchain.endBlockReward
     }
+
+    return reward   
+}
+
+function foundationSubsidies(params, height) {
+    // Calculates the foundation subsidies
+    var reward = BigInt(0)
+
+    // Initial Foundation subsidy
+    if (height == params.blockchain.foundationForkHeight) {
+        reward = reward + params.blockchain.foundationInitialSubsidy
+    }
+
+    // Monthly Foundation subsidy
+    if (height > params.blockchain.foundationForkHeight) {
+        if ((height - params.blockchain.foundationForkHeight) % params.blockchain.foundationSubsidyPeriodicity == 0) {
+            reward = reward + params.blockchain.foundationSubsidy
+        }
+    }
+
     return reward
-    
 }
 
 function newFees(params, api) {

--- a/modules/params.js
+++ b/modules/params.js
@@ -53,7 +53,14 @@ exports.Params = function(config, scriptPath)
         siafundFees: 0.039,
         totalSiafunds: 10000,
         dustThreshold: 1000000000000000000000, // Arbitrary. Bellow this threshold, we consider the amount as "dust" and wont compute it for balances of addresses. 1 milliSia by default
-        coinPrecision: 1000000000000000000000000 // How many Hastings make a coin
+        coinPrecision: 1000000000000000000000000, // How many Hastings make a coin
+        foundationForkHeight: 298000,
+        foundationInitialSubsidy: BigInt(1576800000000000000000000000000000),
+        foundationSubsidy: BigInt(129600000000000000000000000000000),
+        foundationSubsidyPeriodicity: 4320,
+        foundationInitialAddress = "053b2def3cbdd078c19d62ce2b4f0b1a3c5e0ffbeeff01280efb1f8969b2f5bb4fdc680f0807",
+        foundationInitialFailsafeAddress = "27c22a6c6e6645802a3b8fa0e5374657438ef12716d2205d3e866272de1b644dbabd53d6d560",
+        foundationSpecifier = "foundation" // String used to hash the OutputID of Foundation subsidies
     }
 
     // SQL database connection

--- a/modules/params.js
+++ b/modules/params.js
@@ -56,8 +56,8 @@ exports.Params = function(config, scriptPath)
         coinPrecision: 1000000000000000000000000, // How many Hastings make a coin
         foundationForkHeight: 298000,
         foundationInitialSubsidy: BigInt(1576800000000000000000000000000000),
-        foundationSubsidy: BigInt(129600000000000000000000000000000),
-        foundationSubsidyPeriodicity: 4320,
+        foundationSubsidy: BigInt(131400000000000000000000000000000),
+        foundationSubsidyPeriodicity: 4380,
         foundationSpecifier: "foundation" // String used to hash the OutputID of Foundation subsidies
     }
 

--- a/modules/params.js
+++ b/modules/params.js
@@ -58,9 +58,9 @@ exports.Params = function(config, scriptPath)
         foundationInitialSubsidy: BigInt(1576800000000000000000000000000000),
         foundationSubsidy: BigInt(129600000000000000000000000000000),
         foundationSubsidyPeriodicity: 4320,
-        foundationInitialAddress = "053b2def3cbdd078c19d62ce2b4f0b1a3c5e0ffbeeff01280efb1f8969b2f5bb4fdc680f0807",
-        foundationInitialFailsafeAddress = "27c22a6c6e6645802a3b8fa0e5374657438ef12716d2205d3e866272de1b644dbabd53d6d560",
-        foundationSpecifier = "foundation" // String used to hash the OutputID of Foundation subsidies
+        foundationInitialAddress: "053b2def3cbdd078c19d62ce2b4f0b1a3c5e0ffbeeff01280efb1f8969b2f5bb4fdc680f0807",
+        foundationInitialFailsafeAddress: "27c22a6c6e6645802a3b8fa0e5374657438ef12716d2205d3e866272de1b644dbabd53d6d560",
+        foundationSpecifier: "foundation" // String used to hash the OutputID of Foundation subsidies
     }
 
     // SQL database connection

--- a/modules/params.js
+++ b/modules/params.js
@@ -58,8 +58,6 @@ exports.Params = function(config, scriptPath)
         foundationInitialSubsidy: BigInt(1576800000000000000000000000000000),
         foundationSubsidy: BigInt(129600000000000000000000000000000),
         foundationSubsidyPeriodicity: 4320,
-        foundationInitialAddress: "053b2def3cbdd078c19d62ce2b4f0b1a3c5e0ffbeeff01280efb1f8969b2f5bb4fdc680f0807",
-        foundationInitialFailsafeAddress: "27c22a6c6e6645802a3b8fa0e5374657438ef12716d2205d3e866272de1b644dbabd53d6d560",
         foundationSpecifier: "foundation" // String used to hash the OutputID of Foundation subsidies
     }
 

--- a/modules/sql_async.js
+++ b/modules/sql_async.js
@@ -396,7 +396,8 @@ async function createNavigatorTables(params) {
         + "Address char(76), "
         + "CreatedOnBlock int, "
         + "Spent bit, "
-        + "SpentOnBlock int"
+        + "SpentOnBlock int ,"
+        + "FoundationUnclaimed bit"
         + ")"
     sqlQueries[24] = "CREATE INDEX IX_Outputs ON Outputs (Address)"
     sqlQueries[25] = "CREATE INDEX IX_Outputs_1 ON Outputs (CreatedOnBlock)"
@@ -449,6 +450,19 @@ async function createNavigatorTables(params) {
     sqlQueries[36] = "CREATE INDEX IX_StorageProofsInfo ON StorageProofsInfo (Height)"
     sqlQueries[37] = "CREATE INDEX IX_StorageProofsInfo_1 ON StorageProofsInfo (ContractId)"
 
+    // Table for the changes on the main and failover Sia Foundation addresses where the subisdies are deposited
+    sqlQueries[38] =  "CREATE TABLE FoundationAddressesChanges ("
+        + "Height int PRIMARY KEY, "
+        + "FoundationAddress char(76), "
+        + "FailoverAddress char(76)"
+        + ")"
+
+    // Populating the initial entry on FoundationAddressesChanges with values from the Sia API
+    var api = await Commons.MegaRouter(params, 0, '/consensus')
+    var foundationAddress = api.foundationprimaryunlockhash
+    var failoverAddress = api.foundationfailsafeunlockhash
+    sqlQueries[39] = "INSERT INTO FoundationAddressesChanges (Height,FoundationAddress,FailoverAddress) VALUES "
+        + "(0,'" + foundationAddress + "','" + failoverAddress + "')"
 
     // Loop for creating the tables
     for (var i = 0; i < sqlQueries.length; i++) {

--- a/modules/sql_composer.js
+++ b/modules/sql_composer.js
@@ -130,6 +130,12 @@ exports.CreateOutput = function(params, table, outputId, value, address, block) 
         + " END ELSE BEGIN"
         + " UPDATE Outputs SET ScValue = " + value + ", Address = '" + address  + "', CreatedOnBlock = " + block + " WHERE OutputId ='" + outputId + "' END"
     
+    } else if (table == "Outputs-SC-FoundationUnlciamed") {
+        var sqlQuery = "IF (NOT EXISTS(SELECT * FROM Outputs WHERE OutputId='" + outputId + "'))"
+        + " BEGIN INSERT INTO Outputs (OutputId,ScValue,Address,CreatedOnBlock,FoundationUnclaimed) VALUES ('" + outputId + "'," + value + ",'" + address + "'," + block + ",1)"
+        + " END ELSE BEGIN"
+        + " UPDATE Outputs SET ScValue = " + value + ", Address = '" + address  + "', CreatedOnBlock = " + block + ", FoundationUnclaimed = 1 " + " WHERE OutputId ='" + outputId + "' END"
+    
     } else if (table == "Outputs-SF") {
         var sqlQuery = "IF (NOT EXISTS(SELECT * FROM Outputs WHERE OutputId='" + outputId + "'))"
         + " BEGIN INSERT INTO Outputs (OutputId,SfValue,Address,CreatedOnBlock) VALUES ('" + outputId + "'," + value + ",'" + address + "'," + block + ")"

--- a/navigator.js
+++ b/navigator.js
@@ -24,6 +24,7 @@ var SqlComposer = require("./modules/sql_composer.js")
 var Restserver = require('./modules/restserver.js')
 var Watchdog = require('./modules/watchdog.js')
 var WebInjector = require("./modules/webinjector.js")
+var Foundation = require("./foundation.js")
 
 // STARTING
 var currentdate = new Date(); 
@@ -525,6 +526,9 @@ async function checkReorgs(sqlHeight, blocksToIndex, blocksOrphaned) {
         if (blocksOrphaned.length > 0) {
             await saveOrphanedBlocks(blocksOrphaned)
         }
+
+        // Prior to request new block, we check if the addresses of the Sia Foundation have changed
+        await Foundation.CheckCurrentFoundationAddresses(params)
 
         var startTimestamp = Math.floor(Date.now() / 1000)
         blockRequest(blocksToIndex, 0, startTimestamp)

--- a/navigator.js
+++ b/navigator.js
@@ -24,7 +24,7 @@ var SqlComposer = require("./modules/sql_composer.js")
 var Restserver = require('./modules/restserver.js')
 var Watchdog = require('./modules/watchdog.js')
 var WebInjector = require("./modules/webinjector.js")
-var Foundation = require("./foundation.js")
+var Foundation = require("./modules/foundation.js")
 
 // STARTING
 var currentdate = new Date(); 

--- a/package-lock.json
+++ b/package-lock.json
@@ -201,6 +201,11 @@
         }
       }
     },
+    "blakejs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
+      "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
+    },
     "bluebird": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "axios": "^0.19.2",
     "babel-runtime": "^6.26.0",
+    "blakejs": "^1.1.0",
     "body-parser": "^1.19.0",
     "cron": "^1.7.2",
     "csvtojson": "^2.0.10",

--- a/web/nav_assets/navigator_web.js
+++ b/web/nav_assets/navigator_web.js
@@ -964,10 +964,18 @@ function openTab(evt, cityName) {
                 var sizeInBox = 4
                 var subsidy =  300000 - data[1].Height
                 if (subsidy < 30000) {subsidy = 30000} // Minimal future subsidy
-                subsidyReadable = readable(subsidy * 1000000000000000000000000) + " SC"
+                subsidy = subsidy * 1000000000000000000000000
+
+                // Adding Foundation subsidy to coinbase, if exists
+                var foundationSubsidy = 0
+                if (data[2].transactions.length == 2) {
+                    foundationSubsidy = data[2].transactions[1].ScChange
+                }
+
+                subsidyReadable = readable(subsidy + foundationSubsidy) + " SC"
                 addSimpleSenderBox(objectInBox, subsidyReadable, colorInBox, iconInBox, linkInBox, sizeInBox)
                 
-                var minedFees = readable(data[2].transactions[0].ScChange - (subsidy * 1000000000000000000000000)) + " SC"
+                var minedFees = readable(data[2].transactions[0].ScChange - subsidy) + " SC"
                 var objectInBox = "Collected transaction fees"
                 addSimpleSenderBox(objectInBox, minedFees, colorInBox, iconInBox, linkInBox, sizeInBox)
             }
@@ -1008,7 +1016,8 @@ function openTab(evt, cityName) {
                         else if (data[0].Type == "collateralPost" && data[2].transactions[n].TxType != "contractform") {var objectInBox = "Host address"}
                         else if (data[0].Type == "collateralPost" && data[2].transactions[n].TxType == "contractform") {var objectInBox = "Collateral for Contract ID"}
                         else if (data[0].Type == "storageproof") {var objectInBox = "Host address"}
-                        else if (data[0].Type == "blockreward") {var objectInBox = "Miner payout address"}
+                        else if (data[0].Type == "blockreward" && data[2].transactions[n].TxType == "blockreward") {var objectInBox = "Miner payout address"}
+                        else if (data[0].Type == "blockreward" && data[2].transactions[n].TxType == "foundationsub") {var objectInBox = "Sia Foundation address"}
                         else if (data[0].Type == "revision") {var objectInBox = "Address (same wallet)"}
 
                         // Color
@@ -1023,7 +1032,8 @@ function openTab(evt, cityName) {
                         else if (data[0].Type == "collateralPost" && data[2].transactions[n].TxType != "contractform") {iconInBox = "host"}
                         else if (data[0].Type == "collateralPost" && data[2].transactions[n].TxType == "contractform") {iconInBox = "contract"}
                         else if (data[0].Type == "storageproof") {iconInBox = "host"}
-                        else if (data[0].Type == "blockreward") {iconInBox = "miner"}
+                        else if (data[0].Type == "blockreward" && data[2].transactions[n].TxType == "blockreward") {iconInBox = "miner"}
+                        else if (data[0].Type == "blockreward" && data[2].transactions[n].TxType == "foundationsub") {iconInBox = "network"}
 
                         // Pushing the Box to the Scheme
                         addRowReceiver(objectInBox, linkInBox, addressInBox, valueInBox, iconInBox, firstReceiverBool, colorInBox)
@@ -2476,6 +2486,9 @@ function openTab(evt, cityName) {
             var icon = "sfclaim"
         } else if (txType == "blockreward") {
             var type = "Block reward"
+            var icon = "miner"
+        } else if (txType == "foundationsub") {
+            var type = "Foundation subsidy"
             var icon = "miner"
         } else if (txType == "storageproof") {
             var type = "Storage proof"


### PR DESCRIPTION
This PR updates Navigator to handle correctly the Sia fork of block 298000

- Coin supply adjusted to the schedule of subsidies for the Sia Foundation
- Foundation subsidies are shown as part of the Block Reward, assigned to the proper Foundation address and new outputs are created (thanks to Nate Maninger for the help with the code to calculate the outputID hash)
- Changes in the main and failover addresses for the subsidies are tracked on every block. If the main address changes, all the unclaimed outputs from the subsidies (those created at block rewards, but never transferred) will be reassigned to the new address. "AddressesChanges" is also updated on these events
- Web frontend adapted to display correctly the subsidies