### PR TITLE
Calculate output IDs

### DIFF
--- a/modules/indexer.js
+++ b/modules/indexer.js
@@ -281,7 +281,7 @@ async function minerPayoutProcessor(params, sqlBatch, addressesImplicated, heigh
     sqlBatch.push(SqlComposer.InsertSql(params, "HashTypes", toAddHashTypes, minerPayoutTxId))
     
     // Add the new output
-    sqlBatch = await Outputs.MiningPoolPayoutOutput(params, sqlBatch, api, height, payoutAddress)
+    sqlBatch = await Outputs.MiningPoolPayoutOutput(params, sqlBatch, api, height, payoutAddress, 0)
     
     // Mining pool name
     var miningPool = "Unknown" // Default 

--- a/modules/siafunds.js
+++ b/modules/siafunds.js
@@ -78,7 +78,7 @@ exports.sfTransactionProcess = async function(params, apiblock, n, height, times
                     var senderClaimAddress = apiblock.transactions[i].rawtransaction.siafundinputs[j].claimunlockhash
 
                     // Claim output creation
-                    newSql = await Outputs.SfClaimOutput(params, newSql, BigInt(senderClaim), senderClaimAddress, apiblock.transactions[i].id, apiblock.height)
+                    newSql = await Outputs.SfClaimOutput(params, newSql, senderMatcher, BigInt(senderClaim), senderClaimAddress, apiblock.transactions[i].id, apiblock.height)
 
                     // Adding the claim to addressesImplicated with a flag: It is indexed, but we need the info to update the balance of the address
                     addressesImplicated.push({"hash": senderClaimAddress, "sc": senderClaim, "sf": 0, "txType": "SfClaim"})
@@ -149,9 +149,10 @@ exports.sfTransactionProcess = async function(params, apiblock, n, height, times
             senderClaim = senderClaim * apiblock.transactions[n].siafundinputoutputs[j].value // We multiply it by the number of SF transacted
             totalSCtransacted = totalSCtransacted + Math.floor(senderClaim)
             var senderClaimAddress = apiblock.transactions[n].rawtransaction.siafundinputs[j].claimunlockhash
+			const siafundOutputID = apiblock.transactions[n].rawtransaction.siafundinputs[j].parentid
 
             // Claim output creation
-            newSql = await Outputs.SfClaimOutput(params, newSql, BigInt(senderClaim), senderClaimAddress, apiblock.transactions[n].id, apiblock.height)
+            newSql = await Outputs.SfClaimOutput(params, newSql, siafundOutputID, BigInt(senderClaim), senderClaimAddress, apiblock.transactions[n].id, apiblock.height)
 
             // Adding the claim to addressesImplicated with a flag: It is indexed, but we need the info to update the balance of the address
             addressesImplicated.push({"hash": senderClaimAddress, "sc": senderClaim, "sf": 0, txType: "SfClaim"})
@@ -278,9 +279,10 @@ exports.sfSingleTransaction = async function(params, apiblock, n, height, timest
         senderClaim = senderClaim * apiblock.transactions[n].siafundinputoutputs[j].value // We multiply it by the number of SF transacted
         totalSCtransacted = totalSCtransacted + Math.floor(senderClaim)
         var senderClaimAddress = apiblock.transactions[n].rawtransaction.siafundinputs[j].claimunlockhash
+		const siafundOutputID = apiblock.transactions[n].rawtransaction.siafundinputs[j].parentid
 
         // Claim output creation
-        newSql = await Outputs.SfClaimOutput(params, newSql, BigInt(senderClaim), senderClaimAddress, apiblock.transactions[n].id, apiblock.height)
+        newSql = await Outputs.SfClaimOutput(params, newSql, siafundOutputID, BigInt(senderClaim), senderClaimAddress, apiblock.transactions[n].id, apiblock.height)
 
         // Adding the claim to addressesImplicated with a flag of txType
         addressesImplicated.push({"hash": senderClaimAddress, "sc": senderClaim, "sf": 0, txType: "SfClaim"})

--- a/modules/sql_async.js
+++ b/modules/sql_async.js
@@ -95,6 +95,7 @@ exports.BacthInsert = async function(params, sqlBatch, height, indexing) {
         }
 
     } else {
+		let failedItemizedQueries = 0;
         // SQLite does not accept multiple queries on a single message round trip. We always do itemized indexing
         // Besides, according to https://sqlite.org/np1queryprob.html this is not an inefficiency issue for SQLite
         for (var i = 0; i < sqlBatch.length; i++) {


### PR DESCRIPTION
According to the readme, this patch should remove any need for the explorer module. Let me know if there's anywhere else you're pulling data from.

- Calculates the output IDs instead of querying the explorer module.
- Fixes an issue I had with starting up using SQLite

Potential issues:
- It seems like the navigator is only indexing the first miner payout
- I'm not entirely sure I'm grabbing the spent SF output ID correctly